### PR TITLE
Make the API available through PSR-4 and create composer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,21 @@ available options
 ------
 ###### PHP Demo
 
+Install the package in your PHP project:
+
+```bash
+$ composer require shakee93/fonoapi
+```
+
 ```
 <?php
 
-	include_once("fonoapi-v1.php");
+    use Shakee93\Fonoapi\FonoApi;
+
+	require __DIR__.'/vendor/autoload.php';
 
 	$apiKey = "xxxxxxxx"; // get your token key here - https://fonoapi.freshpixl.com
-	$fonoapi = fonoApi::init($apiKey);
+	$fonoapi = FonoApi::init($apiKey);
 	
 		try {
 

--- a/README.md
+++ b/README.md
@@ -27,40 +27,42 @@
 https://fonoapi.freshpixl.com/
 
 
-this is an Api which can provide mobile device descriptions such as model, brand, cpu, gpu, dimensions, release date etc...
-it might be helpful if you are building a website lke gsmarena, phonearena or something similar to that. this api contains a database of a mobile device descriptions of android, apple, ios and old phones too.. :D
-
-this is the php class to communicate with the api. it would be nice if someone can help with other languages though. ;)
+This is an API which can provide mobile device descriptions such as model, brand, CPU, GPU, dimensions, release date etc. It might be helpful if you are building a website like GSMAera, Phonearena or something similar. This API contains a database of a mobile device descriptions of Android, iOS and some old phones too.. :D
+This is the PHP class to communicate with the API. It would be nice if someone can help with other languages though. ;)
 
 ### Api
-Api Url : https://fonoapi.freshpixl.com/v1/
 
-###### Method : getdevice (https://fonoapi.freshpixl.com/v1/getdevice)
-available options
+API URL: https://fonoapi.freshpixl.com/v1/
+
+###### Method `getdevice` (https://fonoapi.freshpixl.com/v1/getdevice)
+
+Available options
   - brand - 
-       pass the Mobile Device Brand (example : "samsung", "htc")
+       Pass the Mobile Device Brand (example : "samsung", "htc")
   - device* - 
-       pass nearly relevent mobile device name (example : "i9305", "A8") 
-       this might result multiple results at a time.
+       Pass nearly relevent mobile device name (example : "i9305", "A8") 
+       This might result multiple results at a time.
   - position -
-       when a set of results is returned you can get a specific device by passing the position of your device on the result set. count starts from 0
+       When a set of results is returned you can get a specific device by passing the position of your device on the result set. count starts from 0
   - token* -
-    - you will need a token to access the Api. no registration, nothing, just grab the key.
-      you can get it here https://fonoapi.freshpixl.com/token/generate
+        You will need a token to access the Api. no registration, nothing, just grab the key.
+        You can get it here https://fonoapi.freshpixl.com/token/generate
 
-###### Method : getlatest (https://fonoapi.freshpixl.com/v1/getlatest)
-available options
+###### Method `getlatest` (https://fonoapi.freshpixl.com/v1/getlatest)
+
+Available options
   - brand - 
        It gives the latest you can filter the brand (example : "samsung", "htc")
   - limit - 
-       limit the result count (Max 100)
+       Limit the result count (Max 100)
   - token* -
-    - you will need a token to access the Api. no registration, nothing, just grab the key.
-      you can get it here https://fonoapi.freshpixl.com/token/generate
+       You will need a token to access the Api. no registration, nothing, just grab the key.<br>
+       You can get it here https://fonoapi.freshpixl.com/token/generate
 
-<strong>NOTE :</strong> the Api will return only 100 devices per request
+<strong>Note:</strong> the API will return only 100 devices per request
 
 ------
+
 ###### PHP Demo
 
 Install the package in your PHP project:
@@ -71,32 +73,27 @@ $ composer require shakee93/fonoapi
 
 ```
 <?php
+use Shakee93\Fonoapi\FonoApi;
 
-    use Shakee93\Fonoapi\FonoApi;
+require __DIR__.'/vendor/autoload.php';
 
-	require __DIR__.'/vendor/autoload.php';
+$apiKey = "xxxxxxxx"; // get your token key here - https://fonoapi.freshpixl.com
+$fonoapi = FonoApi::init($apiKey);
 
-	$apiKey = "xxxxxxxx"; // get your token key here - https://fonoapi.freshpixl.com
-	$fonoapi = FonoApi::init($apiKey);
-	
-		try {
+try {
+    $res = $fonoapi::getDevice("i9305"); // the device you need to get details here
 
-			$res = $fonoapi::getDevice("i9305"); // the device you need to get details here
-
-			foreach ($res as $mobile) {
-				if (!empty($mobile->DeviceName)) 	echo "Device : ". $mobile->DeviceName . "<br>";
-				if (!empty($mobile->Brand)) 		echo "Brand : ". $mobile->Brand . "<br>";
-				if (!empty($mobile->cpu)) 			echo "Cpu : " . $mobile->cpu . "<br>";
-				if (!empty($mobile->status)) 		echo "Status : " . $mobile->status . "<br>";
-				if (!empty($mobile->dimensions)) 	echo "Dimensions : " . $mobile->dimensions . "<br>";
-				if (!empty($mobile->_4g_bands)) 	echo "4g : " .$mobile->_4g_bands . "<br>";
-			}
-
-		} catch (Exception $e) {
-			echo "ERROR : " . $e->getMessage();
-		}
-
-?>
+    foreach ($res as $mobile) {
+        if (!empty($mobile->DeviceName)) 	echo "Device : ". $mobile->DeviceName . "<br>";
+        if (!empty($mobile->Brand)) 		echo "Brand : ". $mobile->Brand . "<br>";
+        if (!empty($mobile->cpu)) 			echo "Cpu : " . $mobile->cpu . "<br>";
+        if (!empty($mobile->status)) 		echo "Status : " . $mobile->status . "<br>";
+        if (!empty($mobile->dimensions)) 	echo "Dimensions : " . $mobile->dimensions . "<br>";
+        if (!empty($mobile->_4g_bands)) 	echo "4g : " .$mobile->_4g_bands . "<br>";
+    }
+} catch (Exception $e) {
+    echo "ERROR : " . $e->getMessage();
+}
 ```
 ------
 
@@ -107,16 +104,20 @@ curl https://fonoapi.freshpixl.com/v1/getdevice -XPOST -H 'Accept: application/j
 ```
 
 ###### Python
- Library is here : https://github.com/jesusperiago/fonoapi
+
+Library is here : https://github.com/jesusperiago/fonoapi
 
 ###### jQuery
- Library is here : https://github.com/shakee93/fonoapi/tree/master/fonoapi-js
+
+Library is here : https://github.com/shakee93/fonoapi/tree/master/fonoapi-js
 
 ###### Nodejs
- Library is here : https://github.com/mtrung/fonoapi/tree/master/fonoapi-nodejs  
- Package is here : https://www.npmjs.com/package/fonoapi-nodejs
+
+Library is here : https://github.com/mtrung/fonoapi/tree/master/fonoapi-nodejs  
+Package is here : https://www.npmjs.com/package/fonoapi-nodejs
 
 ------
 
 ##### Result Set Structure
+
 Check here : https://github.com/shakee93/fonoapi/blob/master/resultset.md

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Shakee93\\Fonoapi\\": "src"
+            "Shakee93\\FonoApi\\": "src"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "shakee93/fonoapi",
+    "description": "FonoApi - Mobile Device Description API",
+    "minimum-stability": "stable",
+    "license": "MIT",
+    "homepage": "https://fonoapi.freshpixl.com",
+    "require": {
+        "php": ">=5.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shakee93\\Fonoapi\\": "src"
+        }
+    }
+}

--- a/src/FonoApi.php
+++ b/src/FonoApi.php
@@ -1,12 +1,13 @@
 <?php
 
+namespace Shakee93\Fonoapi;
+
 /**
  * Class fonoApi v1
  * Author @shakee93
  * Version 1.0.3
  */
-
-class fonoApi
+class FonoApi
 {
 	static $_ApiKey = null;
 	static $debug = false;
@@ -114,7 +115,7 @@ class fonoApi
 			$result["message"] = "Curl Failed" ;
 			$result["innerException"] = $e->getMessage();
 
-			return json_encode($result);	
+			return json_encode($result);
 		}
 	}
 }

--- a/src/FonoApi.php
+++ b/src/FonoApi.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Shakee93\Fonoapi;
+namespace Shakee93\FonoApi;
 
 /**
  * Class fonoApi v1


### PR DESCRIPTION
Things needed for the future:

* Create a composer package on packagist.org
* Code-sniff the API
* Make the API stateful and remove static properties
* Make the API testable

But for now, at least it'd be nice to have the package via `composer require shakee93/fonoapi` :wink: 